### PR TITLE
fix: Replace deprecated splat expression with [*] for Terraform 1.5.6…

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -4,8 +4,8 @@ locals {
   create_all_enabled = local.enabled && var.create_only_integrations_enabled == false
 
   # Team locals to maintain an implicit dependency to downstream modules
-  team_id   = var.create_only_integrations_enabled ? join("", data.opsgenie_team.existing.*.id) : module.team.team_id
-  team_name = var.create_only_integrations_enabled ? join("", data.opsgenie_team.existing.*.name) : coalesce(module.team.team_name, var.name)
+  team_id   = var.create_only_integrations_enabled ? join("", data.opsgenie_team.existing[*].id) : module.team.team_id
+  team_name = var.create_only_integrations_enabled ? join("", data.opsgenie_team.existing[*].name) : coalesce(module.team.team_name, var.name)
 
   members = {
     for member in var.members :


### PR DESCRIPTION
## Terraform 0.12.0+ Splat Operator Updates
## What
Updated Terraform configuration to replace legacy splat syntax 

> (resource.*.attribute)

 with modern bracket-based expressions` (resource[*].attribute).`
Incorporated for expressions where applicable to improve flexibility and readability.
No functional changes to infrastructure; these updates are syntax improvements.
## Why
Aligns with Terraform 0.12.0+ enhancements and first-class expression support.
Improves readability and maintainability of Terraform code.
Prevents potential deprecation warnings by replacing outdated syntax.
## References
[Terraform v0.12.0 Upgrade Guide](https://developer.hashicorp.com/terraform/language/v1.2.x/expressions/splat)



