### PR TITLE
Fix datadog provider configuration

### DIFF
--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,7 +1,7 @@
 // This is a custom provider-datadog.tf because it is always enabled, this is because we always need the datadog provider to be configured, even if the module is disabled.
 
 module "datadog_configuration" {
-  source  = "../datadog-configuration/modules/datadog_keys"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=tags/v1.535.2"
   enabled = true
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Replace relative path for datadog creds module with git reference to the component

## why
* After we split monorepo we can not use relative paths for component references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source of the Datadog configuration module to use a remote GitHub repository instead of a local path. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->