### PR TITLE
fix(terraform): update splat syntax and remove unused vars

### DIFF
--- a/src/modules/integration/main.tf
+++ b/src/modules/integration/main.tf
@@ -8,7 +8,7 @@ locals {
 
   ssm_path = format(var.ssm_path_format, local.name)
 
-  team_id = join("", data.opsgenie_team.default.*.id)
+  team_id = join("", data.opsgenie_team.default[*].id)
 
   append_datadog_tags_enabled = local.enabled && local.is_type_datadog && var.append_datadog_tags_enabled
 }

--- a/src/modules/routing/main.tf
+++ b/src/modules/routing/main.tf
@@ -40,14 +40,14 @@ module "team_routing_rule" {
 
   team_routing_rule = {
     name    = local.team_routing_rule_name
-    team_id = join("", data.opsgenie_team.default.*.id)
+    team_id = join("", data.opsgenie_team.default[*].id)
 
     order = var.order
 
     notify = [{
       type = var.notify.type
       name = try(format(var.team_naming_format, var.team_name, var.notify.name), null)
-      id   = try(join("", data.opsgenie_schedule.notification_schedule.*.id), "")
+      id   = try(join("", data.opsgenie_schedule.notification_schedule[*].id), "")
     }]
 
     criteria = {

--- a/src/modules/routing/variables.tf
+++ b/src/modules/routing/variables.tf
@@ -64,9 +64,3 @@ variable "time_restriction" {
   description = "Time restriction of alert routing rule"
 }
 
-variable "is_default" {
-  type        = bool
-  default     = false
-  description = "Set this alerting route as the default route"
-
-}

--- a/src/opsgenie.context.tf
+++ b/src/opsgenie.context.tf
@@ -1,8 +1,3 @@
-variable "team_name" {
-  type        = string
-  default     = null
-  description = "Current OpsGenie Team Name"
-}
 
 variable "team_naming_format" {
   type        = string

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,5 +1,5 @@
 output "team_members" {
-  value       = local.enabled ? module.members_merge.*.merged : null
+  value       = local.enabled ? module.members_merge[*].merged : null
   description = "Team members"
 }
 


### PR DESCRIPTION
## what

- This updates the syntax for list expansion to the modern splat operator. It also removes some unused or redundant variables to clean up the codebase.

---

* Updated all instances of the deprecated `.*.` splat operator to the modern `[*]` syntax for list expansion in `locals`, `module "team_routing_rule"`, and output definitions, improving compatibility and readability.
* Removed the unused `is_default` variable from `src/modules/routing/variables.tf` to reduce clutter.
* Removed the unused `team_name` variable from `src/opsgenie.context.tf` for better maintainability.

## why

* Remove legacy syntax and maintain best practices

## references

- [TFLint](https://github.com/terraform-linters/tflint)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No new user-facing features.
- Refactor
  - Removed configuration options: is_default (routing module) and team_name (context). Update configurations if you relied on these variables.
- Chores
  - Updated Terraform expressions to modern splat syntax for improved compatibility; no behavioral changes expected.
- Outputs
  - team_members output retains behavior while adopting updated syntax; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->